### PR TITLE
fix: update tooltip to reflect actual behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "category": "Sourcegraph",
         "actionItem": {
           "label": "Export to CSV",
-          "description": "Prints to the browser devtools console"
+          "description": "Download CSV file"
         }
       }
     ],


### PR DESCRIPTION
The current tooltip states that the CSV will be printed to the browser devtools console. I think this is an artifact from the development/WIP version of this extension. Update the tooltip to reflect current behavior (downloading CSV file).

![Screenshot from 2021-06-04 16-02-27](https://user-images.githubusercontent.com/37420160/120857019-aa498d00-c54e-11eb-9aed-db92cbb16d47.png)
![Screenshot from 2021-06-04 16-03-15](https://user-images.githubusercontent.com/37420160/120857025-ac135080-c54e-11eb-961f-b8cb793e9e53.png)
