### PR TITLE
fix: support repository results

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -116,8 +116,8 @@ export function activate(ctx: sourcegraph.ExtensionContext): void {
                 }
 
                 // TODO: This CSV generation is not robust.
-                const results = data.search.results.results,
-                    resultType = '__typename'
+                const results = data.search.results.results
+                const resultType = '__typename'
                 let csvData = new Array()
 
                 if (!results[0]) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,7 +119,7 @@ export function activate(ctx: sourcegraph.ExtensionContext): void {
                 const results = data.search.results.results
                 const resultType = '__typename'
                 let csvData = new Array()
-                
+
                 if (!results?.length || !results[0]) {
                     throw new Error(`No results to be exported.`)
                 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -111,9 +111,9 @@ export function activate(ctx: sourcegraph.ExtensionContext): void {
                 }
 
                 // TODO: This CSV generation is not robust.
-                const results = data.search.results.results;
-                let base64Data = new String;
-                if(results[0]["__typename"]==='FileMatch'){
+                const results = data.search.results.results
+                let base64Data = new String()
+                if (results[0]['__typename'] === 'FileMatch') {
                     const csvData = [
                         [
                             'Repository',
@@ -153,18 +153,13 @@ export function activate(ctx: sourcegraph.ExtensionContext): void {
                         .map(row => row.join(','))
                         .join('\n')
                     base64Data = Base64.encodeURI(csvData)
-                } else if(results[0]["__typename"]==='Repository'){
+                } else if (results[0]['__typename'] === 'Repository') {
                     const csvData = [
-                        [
-                            'Repository',
-                            'Repository external URL',
-                        ],
+                        ['Repository', 'Repository external URL'],
                         ...results.map(r => {
-
-                            return [
-                                r.name,
-                                r.externalURLs[0]?.url,
-                            ].map(s => JSON.stringify(s))
+                            return [r.name, r.externalURLs[0]?.url].map(s =>
+                                JSON.stringify(s)
+                            )
                         }),
                     ]
                         .map(row => row.join(','))

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -116,11 +116,16 @@ export function activate(ctx: sourcegraph.ExtensionContext): void {
                 }
 
                 // TODO: This CSV generation is not robust.
-                const results = data.search.results.results
-                let csvData
-                const resultType = '__typename'
+                const results = data.search.results.results,
+                    resultType = '__typename'
+                let csvData = new Array()
+
+                if (!results[0]) {
+                    throw new Error(`No results to be exported.`)
+                }
 
                 switch (results[0][resultType]) {
+                    // on FileMatch
                     case 'FileMatch':
                         csvData = [
                             [
@@ -159,6 +164,7 @@ export function activate(ctx: sourcegraph.ExtensionContext): void {
                             }),
                         ]
                         break
+                    // on Repository
                     case 'Repository':
                         csvData = [
                             ['Repository', 'Repository external URL'],
@@ -169,12 +175,14 @@ export function activate(ctx: sourcegraph.ExtensionContext): void {
                             ),
                         ]
                         break
+                    // TODO: on CommitSearchResult
                     case 'CommitSearchResult':
                         throw new Error(
                             `Exporting commit/diff search is currently not supported.`
                         )
+                    // If no returned result
                     default:
-                        throw new Error(`No result to be exported.`)
+                        throw new Error(`Please try another query.`)
                 }
 
                 const base64Data = Base64.encodeURI(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,8 +119,8 @@ export function activate(ctx: sourcegraph.ExtensionContext): void {
                 const results = data.search.results.results
                 const resultType = '__typename'
                 let csvData = new Array()
-
-                if (!results[0]) {
+                
+                if (!results?.length || !results[0]) {
                     throw new Error(`No results to be exported.`)
                 }
 
@@ -180,7 +180,7 @@ export function activate(ctx: sourcegraph.ExtensionContext): void {
                         throw new Error(
                             `Exporting commit/diff search is currently not supported.`
                         )
-                    // If no returned result
+                    // If no typename can be found
                     default:
                         throw new Error(`Please try another query.`)
                 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -112,8 +112,9 @@ export function activate(ctx: sourcegraph.ExtensionContext): void {
 
                 // TODO: This CSV generation is not robust.
                 const results = data.search.results.results
-                let base64Data = new String()
-                if (results[0]['__typename'] === 'FileMatch') {
+                let base64Data
+                const resultType = '__typename'
+                if (results[0][resultType] === 'FileMatch') {
                     const csvData = [
                         [
                             'Repository',
@@ -153,14 +154,14 @@ export function activate(ctx: sourcegraph.ExtensionContext): void {
                         .map(row => row.join(','))
                         .join('\n')
                     base64Data = Base64.encodeURI(csvData)
-                } else if (results[0]['__typename'] === 'Repository') {
+                } else if (results[0][resultType] === 'Repository') {
                     const csvData = [
                         ['Repository', 'Repository external URL'],
-                        ...results.map(r => {
-                            return [r.name, r.externalURLs[0]?.url].map(s =>
+                        ...results.map(r =>
+                            [r.name, r.externalURLs[0]?.url].map(s =>
                                 JSON.stringify(s)
                             )
-                        }),
+                        ),
                     ]
                         .map(row => row.join(','))
                         .join('\n')


### PR DESCRIPTION
Users are getting `Cannot read property 'map' of undefined` error because our current code can only process results returned on FileMatch and not on CommitSearchResult or Repository from our GraphQL query.

![image](https://user-images.githubusercontent.com/68532117/131587620-efcf0bc3-b33a-4c64-bb5e-594e8b29dc66.png)

This PR is to add support to results returned from `on Repository`. The exported CSV file would look like this:
![image](https://user-images.githubusercontent.com/68532117/131588295-d4aeb95e-3cd6-42d9-8501-898a54577c03.png)

Also added new error message when trying to export commit / diff searches:
![image](https://user-images.githubusercontent.com/68532117/131587513-319fd304-10a1-4484-ad3c-28755b4625e7.png)


This should resolve the issues addressed in https://github.com/sourcegraph/sourcegraph/issues/22107 & [Internal Slack Thread](https://sourcegraph.slack.com/archives/CKMSNT9C0/p1630446540002500)